### PR TITLE
Disable selenium timeout when running own waits

### DIFF
--- a/atest/automatic_wait_for_testability.robot
+++ b/atest/automatic_wait_for_testability.robot
@@ -3,7 +3,7 @@ Documentation   Verifies automatic injection & waiting features
 Suite Setup     Start Flask App
 Suite Teardown  Final Report
 Test Template   Automatically Call Testability Ready
-Library         SeleniumLibrary  plugins=${CURDIR}/../src/SeleniumTestability;True;29 seconds;False
+Library         SeleniumLibrary  timeout=2 seconds  plugins=${CURDIR}/../src/SeleniumTestability;True;29 seconds;False
 Library         Timer
 Resource        resources.robot
 
@@ -39,3 +39,5 @@ Click All And Verify
   Wait For Testability Ready
   Stop Timer  ${TEST NAME}
   Verify Single Timer  ${LOWER_THAN}  ${HIGHER_THAN}  ${TEST NAME}
+  ${TIMEOUT}=   Get Selenium Timeout
+  Should Be Equal   ${TIMEOUT}  2 seconds

--- a/atest/manual_wait_for_testability.robot
+++ b/atest/manual_wait_for_testability.robot
@@ -47,10 +47,13 @@ Manual Wait For Testability Ready
   [Arguments]  ${BROWSER}  ${ID}
   [Documentation]  test template for manual waiting & injection tests
   Setup Web Environment   ${BROWSER}    ${URL}
+  Set Selenium Timeout  1 second
   Start Timer  ${TEST NAME}
   Click And Wait  ${ID}
   Stop Timer  ${TEST NAME}
   Verify Single Timer  5 seconds  3.5 seconds  ${TEST NAME}
+  ${TIMEOUT}=   Get Selenium Timeout
+  Should Be Equal   ${TIMEOUT}  1 second
   [Teardown]  Teardown Web Environment
 
 Click And Wait

--- a/atest/resources.robot
+++ b/atest/resources.robot
@@ -18,7 +18,6 @@ Setup Web Environment
   [Documentation]  Opens a browser with given url
   ${URL}=  Set Variable  ${URL}
   ${FF_PROFILE}=     Generate Firefox Profile
-  Set Selenium Timeout  10 seconds
   Set Selenium Speed  0 seconds
   Open Browser  ${URL}  browser=${BROWSER}      ff_profile_dir=${FF_PROFILE.path}
   Wait For Document Ready

--- a/src/SeleniumTestability/plugin.py
+++ b/src/SeleniumTestability/plugin.py
@@ -270,7 +270,7 @@ class SeleniumTestability(LibraryComponent):
             local_error_on_timeout = is_truthy(error_on_timeout)
 
         try:
-            WebDriverWait(self.ctx.driver, local_timeout, 0.15).until(
+            WebDriverWait(self.ctx.driver, local_timeout, 0.15, ignored_exceptions=[TimeoutException]).until(
                 lambda x: self.ctx.driver.execute_async_script(JS_LOOKUP["wait_for_testability"])
             )
         except TimeoutException:


### PR DESCRIPTION
Setting selenium timeout will also affects calls to WebDriverWait so if
the timeout set in selenium was smaller SeleniumTestability timeout,
wait for testability ready would fail before its own timeout would
trigger.

TODO: Document the interoperability of selenium timeout and
seleniumtestability timeouts.

Fixes #31