### PR TITLE
fix logging LEVELS

### DIFF
--- a/src/SeleniumTestability/logger.py
+++ b/src/SeleniumTestability/logger.py
@@ -17,7 +17,8 @@ log_name = location / "SeleniumTestability.log"
 log_handler = logging.FileHandler(log_name)
 formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 log_handler.setFormatter(formatter)
-LEVELS = {"FAIL": logging.DEBUG, "WARN": logging.warn, "INFO": logging.INFO, "DEBUG": logging.debug, "TRACE": logging.DEBUG}
+LEVELS = {"FAIL": logging.DEBUG, "WARN": logging.WARN, "INFO": logging.INFO,
+          "DEBUG": logging.DEBUG, "TRACE": logging.DEBUG}
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
When robot --loglevel is set to DEBUG, plugin fails to load with traceback:

```
[ ERROR ] Error in file '/tmp/build/lib/laci_keywords.robot': Initializing test library 'SeleniumLibrary' with arguments [ plugins=SeleniumTestability ] failed: TypeError: Level not an integer or a valid string: <function debug at 0x7fbd21e6a550>
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/SeleniumLibrary/__init__.py", line 461, in __init__
    plugin_libs = self._parse_plugins(plugins)
  File "/usr/local/lib/python3.8/site-packages/SeleniumLibrary/__init__.py", line 589, in _parse_plugins
    plugin = plugin(self, *parsed_plugin.args,
  File "/usr/local/lib/python3.8/site-packages/SeleniumTestability/plugin.py", line 176, in __init__
    self.logger = get_logger("SeleniumTestability")
  File "/usr/local/lib/python3.8/site-packages/SeleniumTestability/logger.py", line 28, in get_logger
    lgr.setLevel(set_to)  # type: ignore
  File "/usr/local/lib/python3.8/logging/__init__.py", line 1409, in setLevel
    self.level = _checkLevel(level)
  File "/usr/local/lib/python3.8/logging/__init__.py", line 197, in _checkLevel
    raise TypeError("Level not an integer or a valid string: %r" % level)

```